### PR TITLE
chore: allow optional passing of ouput folder

### DIFF
--- a/src/logic/git/pushBadges.ts
+++ b/src/logic/git/pushBadges.ts
@@ -1,8 +1,8 @@
 import { getInput } from '@actions/core';
 import { exec } from '@actions/exec';
 
-export const pushBadges = async (): Promise<void> => {
-  await exec('git add', ['./badges']);
+export const pushBadges = async (source = './badges'): Promise<void> => {
+  await exec('git add', [source]);
   await exec('git commit', ['-m', getInput('commit-message')]);
   await exec('git push');
 };

--- a/src/logic/jest/doBadgesExist.ts
+++ b/src/logic/jest/doBadgesExist.ts
@@ -1,6 +1,8 @@
 import { pathExists } from 'fs-extra';
 
-export const doBadgesExist = async (): Promise<boolean> => {
+export const doBadgesExist = async (
+  outputPath = './badges',
+): Promise<boolean> => {
   const files = [
     'coverage-branches.svg',
     'coverage-functions.svg',
@@ -10,7 +12,7 @@ export const doBadgesExist = async (): Promise<boolean> => {
   ];
 
   const exist = await Promise.all(
-    files.map((file) => pathExists(`./badges/${file}`)),
+    files.map((file) => pathExists(`${outputPath}/${file}`)),
   );
 
   return exist.every((el) => el === true);

--- a/src/workflow/actionWorkflow.test.ts
+++ b/src/workflow/actionWorkflow.test.ts
@@ -76,6 +76,30 @@ describe('actionWorkflow function', () => {
     expect(setFailed).toHaveBeenCalledTimes(0);
   });
 
+  it('should check if coverage has not evolved in a custom output folder', async () => {
+    const path = './out-path';
+    jest.mocked(isBranchValidForBadgesGeneration).mockReturnValueOnce(true);
+    jest.mocked(isJestCoverageReportAvailable).mockResolvedValueOnce(true);
+    jest.mocked(doBadgesExist).mockResolvedValueOnce(true);
+    jest.mocked(hasCoverageEvolved).mockResolvedValueOnce(false);
+    jest
+      .mocked(getInput)
+      .mockReturnValueOnce('false')
+      .mockReturnValueOnce('')
+      .mockReturnValueOnce(path);
+
+    await actionWorkflow();
+
+    expect(generateBadges).toHaveBeenCalledTimes(1);
+    expect(setGitConfig).toHaveBeenCalledTimes(0);
+    expect(pushBadges).toHaveBeenCalledTimes(0);
+
+    expect(doBadgesExist).toHaveBeenCalledWith(path);
+
+    expect(info).toHaveBeenCalledTimes(2);
+    expect(setFailed).toHaveBeenCalledTimes(0);
+  });
+
   it('should generate badges and not push them if no-commit is set to true', async () => {
     jest.mocked(isJestCoverageReportAvailable).mockResolvedValueOnce(true);
     jest.mocked(doBadgesExist).mockResolvedValueOnce(true);
@@ -174,6 +198,7 @@ describe('actionWorkflow function', () => {
     expect(generateBadges).toHaveBeenCalledWith(undefined, path);
     expect(setGitConfig).toHaveBeenCalledTimes(1);
     expect(pushBadges).toHaveBeenCalledTimes(1);
+    expect(pushBadges).toHaveBeenCalledWith(path);
 
     expect(info).toHaveBeenCalledTimes(2);
     expect(setFailed).toHaveBeenCalledTimes(0);

--- a/src/workflow/actionWorkflow.ts
+++ b/src/workflow/actionWorkflow.ts
@@ -27,8 +27,6 @@ export const actionWorkflow = async (): Promise<void> => {
       );
     }
 
-    const badgesExist = await doBadgesExist();
-
     const summaryPathInput = getInput('coverage-summary-path');
     const summaryPath = summaryPathInput === '' ? undefined : summaryPathInput;
 
@@ -48,6 +46,8 @@ export const actionWorkflow = async (): Promise<void> => {
       return info("🔶 `no-commit` set to true: badges won't be committed");
     }
 
+    const badgesExist = await doBadgesExist(outputPath);
+
     const hasEvolved = await hasCoverageEvolved(badgesExist);
     if (!hasEvolved) {
       return info('🔶 Coverage has not evolved, no action required.');
@@ -55,7 +55,7 @@ export const actionWorkflow = async (): Promise<void> => {
 
     info('🔶 Pushing badges to the repo');
     await setGitConfig();
-    await pushBadges();
+    await pushBadges(outputPath);
   } catch (error) {
     if (error instanceof Error) {
       return setFailed(`🔶 Oh no! An error occured: ${error.message}`);


### PR DESCRIPTION
- make workflow aware of `output-folder` option
- fallback to default `output-folder` if custom value is unspecified
- update tests to match changes

https://github.com/jpb06/jest-badges-action/issues/46